### PR TITLE
Use effective regexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ It only has a _single method_: `parse(url: string)` which returns the same strin
 ### Deno
 
 ```ts
-import shurley from 'jsr:@brn/shurley@1.0.8'; // or import shurley from 'https://deno.land/x/shurley@1.0.8/mod.ts';
+import { parse } from 'jsr:@brn/shurley'; // or import shurley from 'https://deno.land/x/shurley@1.0.8/mod.ts';
 
-const parsedUrl = shurley.parse('example.com');
+const parsedUrl = parse('example.com');
 
 console.log(parsedUrl); // Outputs 'https://example.com'
 ```

--- a/build-npm.ts
+++ b/build-npm.ts
@@ -1,4 +1,4 @@
-import { build, emptyDir } from 'jsr:@deno/dnt@0.41.3';
+import { build, emptyDir } from '@deno/dnt';
 
 await emptyDir('./npm');
 

--- a/deno.json
+++ b/deno.json
@@ -7,14 +7,12 @@
     "lineWidth": 120,
     "indentWidth": 2,
     "singleQuote": true,
-    "proseWrap": "preserve",
-    "exclude": ["./npm"]
+    "proseWrap": "preserve"
   },
-  "lint": {
-    "exclude": ["./npm"]
-  },
-  "test": {
-    "exclude": ["./npm"]
-  },
-  "lock": false
+  "exclude": ["./npm"],
+  "lock": false,
+  "imports": {
+    "@deno/dnt": "jsr:@deno/dnt@^0.41.3",
+    "@std/assert": "jsr:@std/assert@^1.0.11"
+  }
 }

--- a/mod.ts
+++ b/mod.ts
@@ -4,47 +4,14 @@
  * ```ts
  * parse("example.com") // "https://example.com"
  * parse("http://example.com") // "http://example.com"
- * parse("https://example.com") // "https://example.com"
  * parse("ftp://example.com") // "https://example.com"
  * parse("example.com/path") // "https://example.com/path"
- * parse("example.com/path/to/resource") // "https://example.com/path/to/resource"
- * parse("example.com/path/to/resource?query=string") // "https://example.com/path/to/resource?query=string"
- * parse("example.com/path/to/resource?query=string#fragment") // "https://example.com/path/to/resource?query=string#fragment"
  * ```
  *
  * @param url - The URL to parse.
  * @returns The parsed URL.
  */
-export const parse = (url: string): string => {
-  const parsedUrl = url.trim();
+export const parse = (url: string): string =>
+  /^https?:\/{2,}/.test(url) ? singulate(url) : singulate(`https://${url.replace(/^[^\/]*\/+/, '')}`);
 
-  // Sometimes people get it right
-  if (parsedUrl.startsWith('http://') || url.startsWith('https://')) {
-    return parsedUrl;
-  }
-
-  // Replace all the first "/"'s with "https://"
-  if (parsedUrl.startsWith('/')) {
-    const pattern = /^(\/+)(.*)/;
-    return parsedUrl.replace(pattern, 'https://$2');
-  }
-
-  // Replace anything before ":/" with https
-  if (parsedUrl.includes(':/')) {
-    const pattern = /(.*)(:\/+)(.*)/;
-    return parsedUrl.replace(pattern, 'https://$3');
-  }
-
-  return `https://${parsedUrl}`;
-};
-
-/**
- * This simply exports the `parse` function as the default export.
- *
- * ```ts
- * import shurley from 'jsr:@brn/shurley@1.0.8'; // or import shurley from 'https://deno.land/x/shurley@1.0.8/mod.ts';
- *
- * const parsedUrl = shurley.parse('example.com'); // "https://example.com"
- * ```
- */
-export default { parse };
+const singulate = (url: string) => url.replaceAll(/([^:])\/+/g, '$1/').trim();

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -1,6 +1,6 @@
-import { equal } from 'jsr:@std/assert@1.0.8';
+import { assertEquals } from '@std/assert';
 
-import shurley from './mod.ts';
+import { parse } from './mod.ts';
 
 Deno.test('that .parse() works', () => {
   const tests: { url: string; expected: string }[] = [
@@ -25,15 +25,18 @@ Deno.test('that .parse() works', () => {
     { url: 'https://example.com/', expected: 'https://example.com/' },
     { url: 'https://example.com/something', expected: 'https://example.com/something' },
     { url: 'git:example.com', expected: 'https://git:example.com' },
-    { url: 'https://example.com/?something=true', expected: 'https://example.com/?something=true' },
+    { url: 'https:/example.com/?something=true', expected: 'https://example.com/?something=true' },
     {
       url: 'https://example.com/something?something=true#yeah',
       expected: 'https://example.com/something?something=true#yeah',
     },
+    {
+      url: 'https://example.com/this//route///accidentally////has/////extra//////slashes',
+      expected: 'https://example.com/this/route/accidentally/has/extra/slashes',
+    },
   ];
-
   for (const test of tests) {
-    const parsedUrl = shurley.parse(test.url);
-    equal(parsedUrl, test.expected);
+    const parsedUrl = parse(test.url);
+    assertEquals(parsedUrl, test.expected);
   }
 });


### PR DESCRIPTION
Changed if chain into a single ternary, and removed weird export madness, with the new one, you can still do 
```ts
import * as shurley from "..."
shurley.parse(...)
```
if you want.

Cut down on examples in JSDoc, and changed `equal` in [mod_test.ts](mod_test.ts) to `assertEquals`, because `equal` doesn't throw correctly.